### PR TITLE
ci: update deprecated GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/set-up-node
     - run: npm ci
     - run: npm run lint
@@ -20,9 +20,9 @@ jobs:
     name: Commitlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
 
   autosquash:
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Block Autosquash Commits
         if:  github.event_name != 'merge_group'
-        uses: xt0rted/block-autosquash-commits-action@v2.2.0
+        uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -48,6 +48,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.ENABLE_AUTOMERGE }}
       - name: Autoapprove
-        uses: hmarr/auto-approve-action@v2.1.0
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.APPROVE_AUTOMATIC_PRS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
       last_release_git_tag: ${{ steps.semantic.outputs.last_release_git_tag }}
       last_release_version: ${{ steps.semantic.outputs.last_release_version }}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - uses: ./.github/actions/set-up-node
     - run: npm ci
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@c4a2fa890676fc2db25ad0aacd8ab4a0f1f4c024 # v4.2.1
+      uses: cycjimmy/semantic-release-action@ba330626c4750c19d8299de843f05c7aa5574f62 # v5.0.2
       id: semantic # Need an `id` for output variables
       with:
         semantic_version: 19.0.5


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v3/v4.2.2 → v6.0.2
- Upgrade `wagoid/commitlint-github-action` v5 → v6.2.1
- Pin `xt0rted/block-autosquash-commits-action` v2.2.0 to commit hash
- Upgrade `hmarr/auto-approve-action` v2.1.0 → v4.0.0
- Upgrade `cycjimmy/semantic-release-action` v4.2.1 → v5.0.2
- Pin external actions to commit hashes for security, with version comments for Dependabot

Resolves GitHub Actions Node.js deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)