### PR TITLE
feat: declare typescript as a peer dependency and watch for the next major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,20 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    # Only create pull requests to update lockfiles.
-    # Ignore any new versions that would require package manifest changes.
-    versioning-strategy: lockfile-only
+    # increase-if-necessary so that a new major of a lint dependency -- notably
+    # typescript-eslint, pinned `^8` and otherwise never proposed -- opens a
+    # manifest PR that widens its range. The lint job's check:peer-range then
+    # fails on that PR and prints the typescript peer range to mirror. In-range
+    # updates stay lockfile-only.
+    versioning-strategy: increase-if-necessary
+    ignore:
+      # Hold typescript at its current major. A new major (the TypeScript 7
+      # native rewrite, and every one after) falls outside typescript-eslint's
+      # peer range, so a bump here could only ever produce a PR that
+      # check:peer-range must fail. It becomes adoptable via the
+      # typescript-eslint bump that widens the range, not on its own.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       lint:
         patterns:
@@ -18,4 +29,7 @@ updates:
           - "eslint"
           - "eslint-*"
           - "prettier"
+          # `typescript` is pinned to the range `typescript-eslint` declares,
+          # so the two move together and belong in the same PR.
+          - "typescript"
           - "typescript-eslint"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,14 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/set-up-node
     - run: npm ci
+    # A step of this job rather than a job of its own: it reuses the install
+    # above, and it gates automerge through `needs: [lint]` without adding a job
+    # name that the branch ruleset's required checks would have to be updated
+    # for. It runs before the lint because it is the more specific failure -- on
+    # a Dependabot bump that both drifts the range and breaks the lint, its
+    # message is the one that explains the other.
+    - name: Check the typescript peer range still matches typescript-eslint
+      run: npm run check:peer-range
     - run: npm run lint
 
   commitlint:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Install using **npm**:
 npm i -D @limetech/eslint-config
 ```
 
+If your package contains TypeScript, you also need `typescript` installed, within
+the range this package declares as an optional peer dependency. That range is not
+a preference of ours — it is the range `typescript-eslint` supports, mirrored here
+so that a TypeScript your linter cannot parse is refused by `npm ci` rather than
+crashing halfway through a lint run. See
+[Holding a TypeScript major](#holding-a-typescript-major) below.
+
 Then put a file called `eslint.config.mjs` in your package root, with the following content:
 
 ```js
@@ -42,3 +49,43 @@ This package also exposes a reusable Prettier config that can be used to lint an
 ```js
 export { default } from '@limetech/eslint-config/prettier.config.js';
 ```
+
+## Holding a TypeScript major
+
+`typescript` is an optional peer dependency of this package, pinned to the range
+`typescript-eslint` supports. Consumers doing no type-aware linting still need it:
+`typescript-eslint` parses with it, and `typescript-estree` reads the TypeScript
+compiler API at import time.
+
+That is why a new TypeScript major cannot simply be adopted. TypeScript 7 is the
+native compiler rewrite — its npm package ships platform binaries and no longer
+exposes `ts.SyntaxKind` or `ts.TypeFlags` at all — so linting stops working until
+`typescript-eslint` supports it ([typescript-eslint#10940][tse-issue]).
+
+Consumers should therefore hold `typescript` at its current major in
+`.github/dependabot.yml`:
+
+```yaml
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+```
+
+Note that a TypeScript *minor* can be refused the same way. The peer range's upper
+bound tracks `typescript-eslint`'s, which is minor-granular (`<X.Y.0`), so a minor
+released ahead of their adoption is out of range even though a major-only hold does
+not stop it. Such a bump waits for a widened range rather than being forced through
+with `--legacy-peer-deps`.
+
+The protection is also npm-specific: Yarn treats a peer mismatch as a warning and
+pnpm ships `strict-peer-dependencies=false`, so a consumer on either gets the
+documentation but not the refusal.
+
+When `typescript-eslint` widens its supported range, Dependabot opens a PR here
+that bumps it — a new major included, because `.github/dependabot.yml` uses
+`versioning-strategy: increase-if-necessary`. `check:peer-range` fails that PR and
+prints the range to adopt; widen `peerDependencies.typescript` to match in the
+same PR and release. Consumers pick that up with their next
+`@limetech/eslint-config` bump, and can then drop the `typescript` hold above.
+
+[tse-issue]: https://github.com/typescript-eslint/typescript-eslint/issues/10940

--- a/fixtures/typescript-parser-smoke.ts
+++ b/fixtures/typescript-parser-smoke.ts
@@ -1,0 +1,45 @@
+/**
+ * Gives `npm run lint` some TypeScript-only syntax to parse.
+ *
+ * `typescript-eslint`'s base config sets a parser with no `files` key, so this
+ * repository's JavaScript already goes through `typescript-estree`, and no
+ * block in eslint.config.js matches `.ts` without also matching `.js`. What no
+ * `.js` file can reach is TypeScript-only syntax -- type annotations,
+ * `interface` -- and the TypeScript-aware rules that fire on those nodes.
+ *
+ * This does not guard against an unusable `typescript`. `eslint.config.js`
+ * imports `typescript-eslint` eagerly, and that package throws at module load
+ * for an unsupported major, before any file is selected -- the lint here would
+ * fail with no `.ts` file present at all. The pinned
+ * `devDependencies.typescript` is what keeps that from happening.
+ *
+ * Deliberately dull: not a rule test, just valid TypeScript that the published
+ * config accepts. Excluded from `files` in package.json, so never published.
+ *
+ * See .github/workflows/typescript-major-watch.yml, which lints this file
+ * against the newest published TypeScript to find out whether the `typescript`
+ * peer range can be widened.
+ */
+
+/**
+ * Shape used by {@link describeFixture}.
+ */
+export interface ParserSmokeFixture {
+    /** Human readable name. */
+    name: string;
+
+    /** Arbitrary number, used to give the parser an expression to chew on. */
+    count: number;
+}
+
+/**
+ * Renders a fixture as a string.
+ *
+ * @param fixture - the fixture to describe.
+ * @returns a description of the fixture.
+ */
+export function describeFixture(fixture: ParserSmokeFixture): string {
+    const { name, count } = fixture;
+
+    return `${name}: ${String(count)}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,17 @@
         "prettier": "^3.6.2",
         "typescript-eslint": "^8.39.1"
       },
+      "devDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      },
       "peerDependencies": {
-        "eslint": ">= 9"
+        "eslint": ">= 9",
+        "typescript": ">=4.8.4 <6.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2080,9 +2089,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     }
   },
   "scripts": {
+    "check:peer-range": "node scripts/check-typescript-peer-range.mjs",
     "lint": "eslint --max-warnings=0",
     "lint:fix": "eslint --fix --max-warnings=0"
   },
@@ -62,7 +63,16 @@
     "prettier": "^3.6.2",
     "typescript-eslint": "^8.39.1"
   },
+  "devDependencies": {
+    "typescript": ">=4.8.4 <6.1.0"
+  },
   "peerDependencies": {
-    "eslint": ">= 9"
+    "eslint": ">= 9",
+    "typescript": ">=4.8.4 <6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/scripts/check-typescript-peer-range.mjs
+++ b/scripts/check-typescript-peer-range.mjs
@@ -1,0 +1,137 @@
+/**
+ * Fails if the `typescript` peer range we advertise has drifted away from the
+ * one `typescript-eslint` actually enforces.
+ *
+ * We re-declare that range instead of leaving it implicit because
+ * `typescript-eslint` is a normal dependency of this package, not a peer. npm
+ * is therefore free to satisfy its `typescript` peer with a copy nested under
+ * `node_modules/@limetech/eslint-config`, while the consumer's own
+ * `node_modules/typescript` -- the one `ts-api-utils` resolves, and the one the
+ * editor uses -- is something else entirely. That split installs cleanly and
+ * then dies at lint time (Lundalogik/limepkg-ai-agents#97). Declaring the peer
+ * ourselves puts the conflict back where it belongs: `npm ci`.
+ *
+ * A re-declared range is a copy, and copies rot. `typescript-eslint` widens its
+ * range whenever it adopts a new TypeScript, and Dependabot brings that in here
+ * as a lockfile-only bump that would otherwise look like any other. This check
+ * turns that bump red so the advertised range is updated in the same PR.
+ *
+ * Deliberately offline: it compares against the installed tree, never the
+ * registry, so it is deterministic and cannot fail because of something
+ * published this morning.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Reads and parses a JSON file.
+ *
+ * @param filePath - absolute path to the file.
+ * @returns the parsed contents.
+ */
+function readJson(filePath) {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+const ourManifest = readJson(path.join(repoRoot, 'package.json'));
+
+/**
+ * Reads the installed typescript-eslint manifest.
+ *
+ * @returns the parsed manifest, or undefined if it is not installed.
+ */
+function readUpstreamManifest() {
+    try {
+        return readJson(
+            path.join(
+                repoRoot,
+                'node_modules',
+                'typescript-eslint',
+                'package.json'
+            )
+        );
+    } catch {
+        // Overwhelmingly likely to be no install at all, which would otherwise
+        // surface as a bare ENOENT stack rather than the advice below.
+        return;
+    }
+}
+
+const upstreamManifest = readUpstreamManifest();
+
+const declared = ourManifest.peerDependencies?.typescript;
+const devDeclared = ourManifest.devDependencies?.typescript;
+const upstream = upstreamManifest?.peerDependencies?.typescript;
+
+if (!upstreamManifest) {
+    console.error(
+        'Could not read the installed typescript-eslint. Run `npm ci` first.'
+    );
+    process.exitCode = 1;
+} else if (upstream === undefined) {
+    console.error(
+        `typescript-eslint@${upstreamManifest.version} declares no \`typescript\` ` +
+            'peer range. If upstream really has dropped it, this check has ' +
+            'nothing left to compare against and should be reconsidered.'
+    );
+    process.exitCode = 1;
+} else {
+    // Checked independently rather than as a chain. When upstream widens its
+    // range, both of our copies go stale at once -- that is the normal case
+    // this script exists for -- and reporting them one at a time would cost a
+    // second CI round trip on a Dependabot PR whose automerge is already off.
+    const problems = [];
+
+    if (declared !== upstream) {
+        problems.push(
+            [
+                'The `typescript` peer range in package.json has drifted.',
+                '',
+                `  peerDependencies.typescript:       ${declared ?? '(nothing)'}`,
+                `  typescript-eslint@${upstreamManifest.version} requires: ${upstream}`,
+                '',
+                'Raising the upper bound is a `feat`: it lets consumers move to a',
+                'TypeScript they could not install before. Raising the lower bound',
+                'is breaking -- any consumer below the new floor stops being able to',
+                'run `npm ci` at all -- so check where consumers actually sit before',
+                'releasing that as a minor.',
+            ].join('\n')
+        );
+    }
+
+    if (devDeclared !== upstream) {
+        problems.push(
+            [
+                'The `typescript` devDependency has drifted from that range.',
+                '',
+                `  devDependencies.typescript:       ${devDeclared ?? '(nothing)'}`,
+                `  typescript-eslint@${upstreamManifest.version} requires: ${upstream}`,
+                '',
+                'It is deliberately the same string as the peer range: this copy is',
+                'what lints the TypeScript fixture here, so it has to be a version',
+                'consumers are permitted to use.',
+            ].join('\n')
+        );
+    }
+
+    if (problems.length === 0) {
+        console.log(
+            `✅ typescript peer range matches typescript-eslint@${upstreamManifest.version}: ${upstream}`
+        );
+    } else {
+        const remedy = [
+            'To fix: set both ranges in package.json to the one above, then run',
+            '`npm install` so package-lock.json carries them too, and',
+            '`npm update typescript` to move the pin within the new range.',
+            'Note that `npm i -D typescript@X` is not the command you want -- it',
+            'rewrites the spec to `^X` and trips this check again.',
+        ].join('\n');
+
+        console.error([...problems, remedy].join('\n\n'));
+        process.exitCode = 1;
+    }
+}


### PR DESCRIPTION
Dependabot has been opening `typescript` 7 PRs across every frontend package that
uses this config, and none of them can pass. This is the shared fix.

## Why those PRs can't pass

TypeScript 7 is the native compiler rewrite. Its npm package ships platform
binaries and no longer exports the JavaScript compiler API at all:

```
ts version: 7.0.2
typeof ts.TypeFlags:  undefined
typeof ts.SyntaxKind: undefined
```

`typescript-estree` imports `ts-api-utils` at module load, and `ts-api-utils`
reads that API at import time. So ESLint dies before it looks at a single file.
No published version of the lint stack accepts TypeScript 7 yet —
`typescript-eslint` still declares `typescript ">=4.8.4 <6.1.0"`, and
[typescript-eslint#10940][tse-issue] tracks support for TypeScript >= 7.1.

Worth noting for anyone who goes looking: this is not about type-aware linting.
We do none. `typescript-eslint` still needs a real `typescript` to *parse* with.

## The part that makes this a real trap

In a consumer, the conflict does not surface at install. `typescript-eslint` is a
normal dependency of this package rather than a peer, so npm is free to satisfy
its `typescript` peer with a copy nested under our own `node_modules` — while the
consumer's root `typescript` is something else entirely:

```
node_modules/typescript                                       7.0.2  ← ts-api-utils resolves this
node_modules/@limetech/eslint-config/node_modules/typescript  6.0.3  ← typescript-estree resolves this
```

Two TypeScripts in one lint run. `npm ci` reports success, the build passes, and
then lint dies three levels deep in `node_modules` with
`Cannot read properties of undefined (reading 'Intrinsic')`
(Lundalogik/limepkg-ai-agents#97).

## What this PR does

**Declares `typescript` as an optional peer dependency**, at the range
`typescript-eslint` enforces. This is the substance of the change: it puts the
conflict back where it belongs, at `npm ci`, instead of letting npm nest its way
around it and fail at lint time. Optional, because a consumer that lints no
TypeScript needs none.

**Guards that declaration against rot.** A re-declared range is a copy, and
`typescript-eslint` widens its range whenever it adopts a new TypeScript —
arriving here as a lockfile-only Dependabot bump that looks like any other.
`npm run check:peer-range` turns such a bump red so the advertised range is
updated in the same PR. It runs as a step of the existing lint job, so it reuses
that install and gates automerge without adding a job name the branch ruleset
would have to learn about.

**Pins `typescript` and lints a TypeScript fixture.** Nothing here declared
`typescript`, so the lockfile resolved it transitively to 5.2.2 — a 2023 compiler,
older than any consumer's, and nothing would ever have moved it. It is now an
explicit devDependency at the range we advertise. That pin is what would have
caught an unusable `typescript` here, since `eslint.config.js` imports
`typescript-eslint` eagerly and that package throws at module load for an
unsupported major, before any file is selected.

The fixture covers the narrower thing the pin does not: every source file here is
JavaScript, so the parser was loaded and then never asked to parse anything,
leaving the `.ts`/`.tsx` branches of the published config and `typescript-estree`'s
handling of TypeScript-only syntax exercised nowhere. It is deliberately dull; it
only has to be valid TypeScript that the config accepts.

**Adds a weekly watcher.** Consumers now hold `typescript` at their current major
in `dependabot.yml`, and those holds are released by widening the range here.
Nothing would have told us when that becomes possible — a comment on an ignore
rule records an exit condition, it does not fire. `typescript-major-watch.yml`
installs the newest published TypeScript, runs the real lint against it, and
opens a tracking issue when it works.

A few deliberate choices in the watcher:

- **It stays green while blocked**, reporting to the step summary. A scheduled job
  that sits red for months gets muted, and would be worthless at the moment it
  finally has news. The signal is an issue, not a job status.
- **It does not read version metadata**, it performs the real install — so a
  blocker anywhere in the tree is caught without this file knowing about it.
- **Installing and linting are asked separately**, because they are different
  questions and only the second is the news.
- **It never retires.** Unlike a one-off dependency hold, every future TypeScript
  major asks the same question again, so when the declared range already covers
  the newest major it simply says so and exits.

## Compatibility

The range is not a preference of ours — it mirrors what `typescript-eslint`
enforces, and `check:peer-range` fails if the two ever diverge.

Existing installs are unaffected: this only takes effect when a consumer resolves
the new version. From then on a `typescript` outside the range is refused at
`npm ci` instead of producing a tree whose lint may or may not work depending on
how npm happened to hoist it. A consumer sitting outside the range therefore has
to move TypeScript before it can take this update, which is the intended
behaviour rather than a side effect — the alternative is the silent split tree
this PR exists to eliminate.

Note that the upper bound is minor-granular, following `typescript-eslint`'s own
convention, so a TypeScript *minor* released ahead of their adoption is out of
range too. The README says so, since a major-only Dependabot hold does not
prevent it.

## Verification

- Reproduced both halves of the peer behaviour: a direct dependency's peer
  conflict is a hard `npm error code ERESOLVE`; the same peer one level down is
  not, and installs the split tree shown above.
- `check:peer-range` exits 1 with the correct range printed when the declaration
  drifts, and 0 when it matches.
- Drove all four watcher branches with a stubbed npm: range-covers-latest,
  install refused, install succeeded but tree stale, install plus version match.
- Forced TypeScript 7 into the tree and confirmed `npm run lint` fails — which is
  what the watcher is looking for the absence of.
- `npm ci`, `npm run lint` and `npm run check:peer-range` all clean after rebase.
- `actionlint` clean on the new workflow.

## Deliberately not done: splitting the watcher into two jobs

The watcher runs `npm install typescript@latest` (unpinned, lifecycle scripts on)
in the same job that later holds `GITHUB_TOKEN` to open the tracking issue. A
lifecycle script in a compromised `typescript` tree could write `$GITHUB_PATH` or
`$GITHUB_OUTPUT`, which the token-holding steps inherit. The clean close is a
two-job split: a token-less job installs and lints and emits its verdict as
outputs, a second job opens the issue and runs nothing untrusted.

Consciously deferred. The token is `contents: read` + `issues: write`, ephemeral,
on a public repo, and exploitation requires an upstream supply-chain compromise of
`typescript` itself. Against that narrow window, the split adds a second job and
the plumbing of the verdict and log through job outputs — complexity this
otherwise self-contained workflow does not otherwise need. Recorded here so it is
a settled decision rather than an open question: revisit if the token's scope
grows or the job starts installing more than it does today.

## After this merges

Release, then each consuming repository bumps `@limetech/eslint-config` and adds
the `typescript` major hold. Its own open TypeScript 7 PR can then be closed —
it is squatting a Dependabot slot it can never vacate on its own.

[tse-issue]: https://github.com/typescript-eslint/typescript-eslint/issues/10940



